### PR TITLE
实际系统中存在slots只有单个字典的情况

### DIFF
--- a/oBIX/common/util.py
+++ b/oBIX/common/util.py
@@ -76,7 +76,8 @@ class Util(object):
                 data_type_str = data_type_str.split(":")[-1]
 
             point.data_type = Util.parse_data_type(data_type_str)
-
+            if type(slots) == dict:
+                slots = [slots]
             for slot in slots:
                 name = slot["@name"]
                 value_str = None


### PR DESCRIPTION
如果slots只有一个字典，会存在 
 File "/***/site-packages/oBIX/common/util.py", line 81, in parse_point
    name = slot["@name"]
TypeError: string indices must be integers

提前判断是否只有单个slot，套一层list可以解决问题